### PR TITLE
Add structure to SBOM and relationships to avoid lingering nodes

### DIFF
--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -30,14 +30,21 @@ type CreationInfo struct {
 	Created  string   `json:"created"`
 }
 
+type Relationship struct {
+	Element string `json:"spdxElementId"`
+	Type    string `json:"relationshipType"`
+	Related string `json:"relatedSpdxElement"`
+}
+
 type Doc struct {
 	SPDXVersion       string `json:"spdxVersion"`
 	DataLicense       string `json:"dataLicense"`
 	SPDXID            string
-	Name              string       `json:"name"`
-	DocumentNamespace string       `json:"documentNamespace"`
-	CreationInfo      CreationInfo `json:"creationInfo"`
-	Packages          []Package    `json:"packages"`
+	Name              string         `json:"name"`
+	DocumentNamespace string         `json:"documentNamespace"`
+	CreationInfo      CreationInfo   `json:"creationInfo"`
+	Packages          []Package      `json:"packages"`
+	Relationships     []Relationship `json:"relationships"`
 }
 
 func MakeDoc(host, owner, name string, packages []Package) Doc {
@@ -65,7 +72,7 @@ func MakeDoc(host, owner, name string, packages []Package) Doc {
 		Supplier:         "NOASSERTION",
 	}
 
-	return Doc{
+	doc := Doc{
 		SPDXVersion:       "SPDX-2.3",
 		DataLicense:       "CC0-1.0",
 		SPDXID:            "SPDXRef-DOCUMENT",
@@ -75,6 +82,9 @@ func MakeDoc(host, owner, name string, packages []Package) Doc {
 			Creators: []string{"Organization: GitHub, Inc", "Tool: gh-sbom"},
 			Created:  time.Now().UTC().Format("2006-01-02T15:04:05Z"),
 		},
-		Packages: append([]Package{mainPackage}, packages...),
+		Relationships: []Relationship{},
+		Packages:      append([]Package{mainPackage}, packages...),
 	}
+
+	return doc
 }

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -86,5 +86,13 @@ func MakeDoc(host, owner, name string, packages []Package) Doc {
 		Packages:      append([]Package{mainPackage}, packages...),
 	}
 
+	for _, p := range doc.Packages {
+		doc.Relationships = append(doc.Relationships, Relationship{
+			Element: "SPDXRef-mainPackage",
+			Type:    "DEPENDS_ON",
+			Related: p.SPDXID,
+		})
+	}
+
 	return doc
 }

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -45,6 +45,7 @@ type Doc struct {
 	CreationInfo      CreationInfo   `json:"creationInfo"`
 	Packages          []Package      `json:"packages"`
 	Relationships     []Relationship `json:"relationships"`
+	DocumentDescribes []string       `json:"documentDescribes"`
 }
 
 func MakeDoc(host, owner, name string, packages []Package) Doc {
@@ -82,13 +83,14 @@ func MakeDoc(host, owner, name string, packages []Package) Doc {
 			Creators: []string{"Organization: GitHub, Inc", "Tool: gh-sbom"},
 			Created:  time.Now().UTC().Format("2006-01-02T15:04:05Z"),
 		},
-		Relationships: []Relationship{},
-		Packages:      append([]Package{mainPackage}, packages...),
+		Relationships:     []Relationship{},
+		Packages:          append([]Package{mainPackage}, packages...),
+		DocumentDescribes: []string{mainPackage.SPDXID},
 	}
 
 	for _, p := range doc.Packages {
 		doc.Relationships = append(doc.Relationships, Relationship{
-			Element: "SPDXRef-mainPackage",
+			Element: mainPackage.SPDXID,
 			Type:    "DEPENDS_ON",
 			Related: p.SPDXID,
 		})

--- a/pkg/spdx/spdx.go
+++ b/pkg/spdx/spdx.go
@@ -44,6 +44,27 @@ func MakeDoc(host, owner, name string, packages []Package) Doc {
 	// https://spdx.github.io/spdx-spec/v2.3/
 	docName := fmt.Sprintf("%s/%s/%s", host, owner, name)
 
+	mainPackage := Package{
+		Name:        name,
+		SPDXID:      "SPDXRef-mainPackage",
+		VersionInfo: "",
+		DownloadLocation: fmt.Sprintf(
+			"git+https://%s/%s/%s.git",
+			host, owner, name,
+		),
+		FilesAnalyzed: false,
+		ExternalRefs: []ExternalRef{
+			{
+				ReferenceCategory: "PACKAGE-MANAGER",
+				ReferenceType:     "purl",
+				ReferenceLocator:  fmt.Sprintf("pkg:github/%s/%s", owner, name),
+			},
+		},
+		LicenseConcluded: "NOASSERTION",
+		LicenseDeclared:  "NOASSERTION",
+		Supplier:         "NOASSERTION",
+	}
+
 	return Doc{
 		SPDXVersion:       "SPDX-2.3",
 		DataLicense:       "CC0-1.0",
@@ -54,6 +75,6 @@ func MakeDoc(host, owner, name string, packages []Package) Doc {
 			Creators: []string{"Organization: GitHub, Inc", "Tool: gh-sbom"},
 			Created:  time.Now().UTC().Format("2006-01-02T15:04:05Z"),
 		},
-		Packages: packages,
+		Packages: append([]Package{mainPackage}, packages...),
 	}
 }


### PR DESCRIPTION
This is a really cool project thanks for writing it! I have a suggestion to improve the SPDX SBOM and fix a bug.

This PR modifies the SPDX SBOM to add relationships and add structure by relating them to a main package. It also fixes a bug where no packages were listed as being described by the document.

Before, packages were lingering loose, now they are related to one main package to model them as components an not individual items. Visualizing the SBOM structure with [bom](https://github.com/kubernetes-sigs/bom) we can see that the SBOM now looks like this:

```
 gh-sbom |  bom document outline -


 📂 SPDX Document github.com/advanced-security/gh-sbom
  │ 
  │ 📦 DESCRIBES 1 Packages
  │ 
  ├ gh-sbom
  │  │ 🔗 20 Relationships
  │  ├ DEPENDS_ON PACKAGE gh-sbom
  │  ├ DEPENDS_ON PACKAGE go-gh@1.2.1
  │  ├ DEPENDS_ON PACKAGE safeexec@1.0.0
  │  ├ DEPENDS_ON PACKAGE go-runewidth@0.0.13
  │  ├ DEPENDS_ON PACKAGE uuid@1.3.0
  │  ├ DEPENDS_ON PACKAGE uniseg@0.2.0
  │  ├ DEPENDS_ON PACKAGE pflag@1.0.5
  │  ├ DEPENDS_ON PACKAGE net@0.7.0
  │  ├ DEPENDS_ON PACKAGE term@0.5.0
  │  ├ DEPENDS_ON PACKAGE httpretty@0.0.6
  │  ├ DEPENDS_ON PACKAGE go-colorful@1.2.0
  │  ├ DEPENDS_ON PACKAGE termenv@0.12.0
  │  ├ DEPENDS_ON PACKAGE shurcool-graphql@0.0.2
  │  ├ DEPENDS_ON PACKAGE text@0.2.0
  │  ├ DEPENDS_ON PACKAGE go-isatty@0.0.16
  │  ├ DEPENDS_ON PACKAGE go-timezone-local@0.0.0-20210907160436-ef149e42d28e
  │  ├ DEPENDS_ON PACKAGE sys@0.5.0
  │  ├ DEPENDS_ON PACKAGE yaml.v3@3.0.1
  │  ├ DEPENDS_ON PACKAGE checkout@3
  │  └ DEPENDS_ON PACKAGE gh-extension-precompile@1
  │ 
  └ 📄 DESCRIBES 0 Files


```

